### PR TITLE
5: local dev compose exists now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: dev_dashdb
+      POSTGRES_USER: web
+      POSTGRES_PASSWORD: webpass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
local docker compose created.

# Test Steps

- should be able to run `docker compose up` and start the docker container for postgres now.

- which means you should be able to actually run the backend now as well!!!!
- `go run ./...` from the backend project and you should see output that the http server has started on 8080
