### PR TITLE
Normalize backend datetimes to UTC

### DIFF
--- a/backend/db/database.go
+++ b/backend/db/database.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -28,6 +29,10 @@ func OpenDB(dbConfig config.DBConfig) (*pgxpool.Pool, error) {
 	poolConfig.MaxConns = int32(dbConfig.MaxConns)
 	poolConfig.MaxConnIdleTime = dbConfig.MaxConnIdleTime
 	poolConfig.MinConns = int32(dbConfig.MinConns)
+	poolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET TIME ZONE 'UTC'")
+		return err
+	}
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
 	if err != nil {

--- a/backend/internal/models/mocks.go
+++ b/backend/internal/models/mocks.go
@@ -1,6 +1,6 @@
 package models
 
-import "time"
+import "DevDash/pkg/utils"
 
 type MockDB struct {
 	Users    map[string]User
@@ -15,12 +15,12 @@ func NewMockDB() *MockDB {
 	db.Users["01"] = User{
 		ID: 1, UUID: "01", Name: "User 1",
 		Email: "user1@example.com", PasswordHash: "123123",
-		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		CreatedAt: utils.NowUTC(), UpdatedAt: utils.NowUTC(),
 	}
 	db.Users["02"] = User{
 		ID: 2, UUID: "02", Name: "User 2",
 		Email: "user2@example.com", PasswordHash: "123123",
-		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		CreatedAt: utils.NowUTC(), UpdatedAt: utils.NowUTC(),
 	}
 
 	db.Projects["01"] = Project{
@@ -28,7 +28,7 @@ func NewMockDB() *MockDB {
 		Description: "this is a description for project 1",
 		Status:      "in progress", Stack: "golang, react",
 		RepositoryURL: "example.com", DeploymentURL: "example.com",
-		UserID: 1, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		UserID: 1, CreatedAt: utils.NowUTC(), UpdatedAt: utils.NowUTC(),
 	}
 	return db
 }

--- a/backend/internal/models/project.go
+++ b/backend/internal/models/project.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"DevDash/pkg/utils"
+	"time"
+)
 
 type Project struct {
 	ID            int64     `json:"id"`
@@ -48,9 +51,15 @@ type ProjectResponse struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
+func (p *Project) NormalizeTimestamps() {
+	p.CreatedAt = utils.ToUTC(p.CreatedAt)
+	p.UpdatedAt = utils.ToUTC(p.UpdatedAt)
+}
+
 func (p *Project) ToResponse() ProjectResponse {
+	p.NormalizeTimestamps()
 	return ProjectResponse{
-		UUID:            p.UUID,
+		UUID:          p.UUID,
 		Name:          p.Name,
 		Description:   p.Description,
 		Status:        p.Status,

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"DevDash/pkg/utils"
+	"time"
+)
 
 type User struct {
 	ID           int64     `json:"id"`
@@ -31,9 +34,15 @@ type UserResponse struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+func (u *User) NormalizeTimestamps() {
+	u.CreatedAt = utils.ToUTC(u.CreatedAt)
+	u.UpdatedAt = utils.ToUTC(u.UpdatedAt)
+}
+
 func (u *User) ToResponse() UserResponse {
+	u.NormalizeTimestamps()
 	return UserResponse{
-		UUID:        u.UUID,
+		UUID:      u.UUID,
 		Name:      u.Name,
 		Email:     u.Email,
 		CreatedAt: u.CreatedAt,

--- a/backend/internal/repositories/mocks.go
+++ b/backend/internal/repositories/mocks.go
@@ -2,8 +2,10 @@ package repositories
 
 import (
 	"DevDash/internal/models"
+	"DevDash/pkg/utils"
 	"context"
 	"errors"
+	"fmt"
 )
 
 func NewMockRepo(db *models.MockDB) *Repository {
@@ -46,11 +48,22 @@ func (r *UserRepositoryMock) GetByEmail(ctx context.Context, email string) (*mod
 }
 
 func (r *UserRepositoryMock) Create(ctx context.Context, user *models.User) error {
+	if user.UUID == "" {
+		user.UUID = fmt.Sprintf("user-%d", len(r.DB.Users)+1)
+	}
+	if user.ID == 0 {
+		user.ID = int64(len(r.DB.Users) + 1)
+	}
+	now := utils.NowUTC()
+	user.CreatedAt = now
+	user.UpdatedAt = now
 	r.DB.Users[user.UUID] = *user
 	return nil
 }
 
 func (r *UserRepositoryMock) Update(ctx context.Context, user *models.User) error {
+	user.UpdatedAt = utils.NowUTC()
+	user.NormalizeTimestamps()
 	r.DB.Users[user.UUID] = *user
 	return nil
 }
@@ -92,11 +105,22 @@ func (r *ProjectRepositoryMock) GetAllByUserID(ctx context.Context, userID int64
 }
 
 func (r *ProjectRepositoryMock) Create(ctx context.Context, project *models.Project) error {
+	if project.UUID == "" {
+		project.UUID = fmt.Sprintf("project-%d", len(r.DB.Projects)+1)
+	}
+	if project.ID == 0 {
+		project.ID = int64(len(r.DB.Projects) + 1)
+	}
+	now := utils.NowUTC()
+	project.CreatedAt = now
+	project.UpdatedAt = now
 	r.DB.Projects[project.UUID] = *project
 	return nil
 }
 
 func (r *ProjectRepositoryMock) Update(ctx context.Context, project *models.Project) error {
+	project.UpdatedAt = utils.NowUTC()
+	project.NormalizeTimestamps()
 	r.DB.Projects[project.UUID] = *project
 	return nil
 }

--- a/backend/internal/repositories/project_repository.go
+++ b/backend/internal/repositories/project_repository.go
@@ -31,6 +31,7 @@ func (r *projectRepository) GetByID(ctx context.Context, id int64) (*models.Proj
 	if err != nil {
 		return nil, err
 	}
+	project.NormalizeTimestamps()
 	return &project, nil
 }
 
@@ -45,6 +46,7 @@ func (r *projectRepository) GetByUUID(ctx context.Context, uuid string) (*models
 	if err != nil {
 		return nil, err
 	}
+	project.NormalizeTimestamps()
 	return &project, nil
 }
 
@@ -105,6 +107,7 @@ func (r *projectRepository) GetAllByUserID(ctx context.Context, userID int64) ([
 		if err != nil {
 			return nil, err
 		}
+		p.NormalizeTimestamps()
 		projects = append(projects, p)
 	}
 

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -31,6 +31,7 @@ func (r *userRepository) GetByID(ctx context.Context, id int64) (*models.User, e
 	if err != nil {
 		return nil, err
 	}
+	user.NormalizeTimestamps()
 	return &user, nil
 }
 
@@ -45,6 +46,7 @@ func (r *userRepository) GetByUUID(ctx context.Context, id string) (*models.User
 	if err != nil {
 		return nil, err
 	}
+	user.NormalizeTimestamps()
 	return &user, nil
 }
 
@@ -59,6 +61,7 @@ func (r *userRepository) GetByEmail(ctx context.Context, email string) (*models.
 	if err != nil {
 		return nil, err
 	}
+	user.NormalizeTimestamps()
 	return &user, nil
 }
 
@@ -78,7 +81,7 @@ func (r *userRepository) Create(ctx context.Context, user *models.User) error {
 func (r *userRepository) Update(ctx context.Context, user *models.User) error {
 	query := `
 		UPDATE users
-		SET name = $1, email = $2
+		SET name = $1, email = $2, updated_at = NOW()
 		WHERE uuid = $3
 	`
 	_, err := r.db.Exec(ctx, query, user.Name, user.Email, user.UUID)

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -57,7 +57,11 @@ func (s *projectService) Create(ctx context.Context, req models.CreateProjectReq
 	if err != nil {
 		return nil, err
 	}
-	return new(project.ToResponse()), nil
+	created, err := s.projectRepo.GetByUUID(ctx, project.UUID)
+	if err != nil {
+		return nil, err
+	}
+	return new(created.ToResponse()), nil
 }
 
 func (s *projectService) Update(ctx context.Context, id string, req models.UpdateProjectRequest) (*models.ProjectResponse, error) {
@@ -76,7 +80,11 @@ func (s *projectService) Update(ctx context.Context, id string, req models.Updat
 	if err != nil {
 		return nil, err
 	}
-	return new(project.ToResponse()), nil
+	updated, err := s.projectRepo.GetByUUID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return new(updated.ToResponse()), nil
 }
 
 func (s *projectService) Delete(ctx context.Context, id string) error {

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -57,7 +57,11 @@ func (s *userService) Create(ctx context.Context, req models.CreateUserRequest) 
 	if err != nil {
 		return nil, err
 	}
-	return new(user.ToResponse()), nil
+	created, err := s.userRepo.GetByUUID(ctx, user.UUID)
+	if err != nil {
+		return nil, err
+	}
+	return new(created.ToResponse()), nil
 }
 
 func (s *userService) Update(ctx context.Context, id string, req models.UpdateUserRequest) (*models.UserResponse, error) {
@@ -71,7 +75,11 @@ func (s *userService) Update(ctx context.Context, id string, req models.UpdateUs
 	if err != nil {
 		return nil, err
 	}
-	return new(user.ToResponse()), nil
+	updated, err := s.userRepo.GetByUUID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return new(updated.ToResponse()), nil
 }
 
 func (s *userService) Delete(ctx context.Context, id string) error {

--- a/backend/pkg/utils/time.go
+++ b/backend/pkg/utils/time.go
@@ -1,0 +1,11 @@
+package utils
+
+import "time"
+
+func NowUTC() time.Time {
+	return time.Now().UTC()
+}
+
+func ToUTC(t time.Time) time.Time {
+	return t.UTC()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures all backend datetime handling uses UTC so Postgres `TIMESTAMPTZ` values stay consistent regardless of server or container timezone.

## Changes

- Added `pkg/utils/time.go` with `NowUTC()` and `ToUTC()` helpers
- Normalized `CreatedAt` / `UpdatedAt` on `User` and `Project` models via `NormalizeTimestamps()`, called from repositories and `ToResponse()`
- Updated mock data and mock repositories to use UTC timestamps and assign IDs on create (matching real DB behavior)
- Set `SET TIME ZONE 'UTC'` on every new Postgres connection in `db/database.go`
- Aligned `user_repository.Update` with projects by setting `updated_at = NOW()`
- Refetched records after create/update in services so API responses return database-backed UTC timestamps

## Testing

- `go build ./...`
- `go test -tags=integration ./Test/Unit/... -count=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-228ad680-ad23-4af3-a74c-30e54f2b3874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-228ad680-ad23-4af3-a74c-30e54f2b3874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

