### PR TITLE
Fix backend datetime handling to store and return UTC timestamps

### DIFF
--- a/backend/db/database.go
+++ b/backend/db/database.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -28,6 +29,10 @@ func OpenDB(dbConfig config.DBConfig) (*pgxpool.Pool, error) {
 	poolConfig.MaxConns = int32(dbConfig.MaxConns)
 	poolConfig.MaxConnIdleTime = dbConfig.MaxConnIdleTime
 	poolConfig.MinConns = int32(dbConfig.MinConns)
+	poolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET TIME ZONE 'UTC'")
+		return err
+	}
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
 	if err != nil {

--- a/backend/db/migrations/000005_set_updated_at_triggers.down.sql
+++ b/backend/db/migrations/000005_set_updated_at_triggers.down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS set_projects_updated_at ON projects;
+DROP TRIGGER IF EXISTS set_users_updated_at ON users;
+DROP FUNCTION IF EXISTS trigger_set_updated_at();

--- a/backend/db/migrations/000005_set_updated_at_triggers.up.sql
+++ b/backend/db/migrations/000005_set_updated_at_triggers.up.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION trigger_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE FUNCTION trigger_set_updated_at();
+
+CREATE TRIGGER set_projects_updated_at
+    BEFORE UPDATE ON projects
+    FOR EACH ROW
+    EXECUTE FUNCTION trigger_set_updated_at();

--- a/backend/internal/models/mocks.go
+++ b/backend/internal/models/mocks.go
@@ -1,6 +1,6 @@
 package models
 
-import "time"
+import "DevDash/pkg/utils"
 
 type MockDB struct {
 	Users    map[string]User
@@ -15,12 +15,12 @@ func NewMockDB() *MockDB {
 	db.Users["01"] = User{
 		ID: 1, UUID: "01", Name: "User 1",
 		Email: "user1@example.com", PasswordHash: "123123",
-		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		CreatedAt: utils.NowUTC(), UpdatedAt: utils.NowUTC(),
 	}
 	db.Users["02"] = User{
 		ID: 2, UUID: "02", Name: "User 2",
 		Email: "user2@example.com", PasswordHash: "123123",
-		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		CreatedAt: utils.NowUTC(), UpdatedAt: utils.NowUTC(),
 	}
 
 	db.Projects["01"] = Project{
@@ -28,7 +28,7 @@ func NewMockDB() *MockDB {
 		Description: "this is a description for project 1",
 		Status:      "in progress", Stack: "golang, react",
 		RepositoryURL: "example.com", DeploymentURL: "example.com",
-		UserID: 1, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		UserID: 1, CreatedAt: utils.NowUTC(), UpdatedAt: utils.NowUTC(),
 	}
 	return db
 }

--- a/backend/internal/repositories/mocks.go
+++ b/backend/internal/repositories/mocks.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"DevDash/internal/models"
+	"DevDash/pkg/utils"
 	"context"
 	"errors"
 )
@@ -46,11 +47,15 @@ func (r *UserRepositoryMock) GetByEmail(ctx context.Context, email string) (*mod
 }
 
 func (r *UserRepositoryMock) Create(ctx context.Context, user *models.User) error {
+	now := utils.NowUTC()
+	user.CreatedAt = now
+	user.UpdatedAt = now
 	r.DB.Users[user.UUID] = *user
 	return nil
 }
 
 func (r *UserRepositoryMock) Update(ctx context.Context, user *models.User) error {
+	user.UpdatedAt = utils.NowUTC()
 	r.DB.Users[user.UUID] = *user
 	return nil
 }
@@ -92,11 +97,15 @@ func (r *ProjectRepositoryMock) GetAllByUserID(ctx context.Context, userID int64
 }
 
 func (r *ProjectRepositoryMock) Create(ctx context.Context, project *models.Project) error {
+	now := utils.NowUTC()
+	project.CreatedAt = now
+	project.UpdatedAt = now
 	r.DB.Projects[project.UUID] = *project
 	return nil
 }
 
 func (r *ProjectRepositoryMock) Update(ctx context.Context, project *models.Project) error {
+	project.UpdatedAt = utils.NowUTC()
 	r.DB.Projects[project.UUID] = *project
 	return nil
 }

--- a/backend/internal/repositories/project_repository.go
+++ b/backend/internal/repositories/project_repository.go
@@ -52,9 +52,11 @@ func (r *projectRepository) Create(ctx context.Context, project *models.Project)
 	query := `
 		INSERT INTO projects (name, description, status, stack, repository_url, deployment_url, user_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		RETURNING id, uuid
+		RETURNING id, uuid, created_at, updated_at
 	`
-	err := r.db.QueryRow(ctx, query, project.Name, project.Description, project.Status, project.Stack, project.RepositoryURL, project.DeploymentURL, project.UserID).Scan(&project.ID, &project.UUID)
+	err := r.db.QueryRow(ctx, query, project.Name, project.Description, project.Status, project.Stack, project.RepositoryURL, project.DeploymentURL, project.UserID).Scan(
+		&project.ID, &project.UUID, &project.CreatedAt, &project.UpdatedAt,
+	)
 	if err != nil {
 		return err
 	}
@@ -66,8 +68,9 @@ func (r *projectRepository) Update(ctx context.Context, project *models.Project)
 		UPDATE projects
 		SET name = $1, description = $2, status = $3, stack = $4, repository_url = $5, deployment_url = $6, updated_at = NOW()
 		WHERE uuid = $7
+		RETURNING updated_at
 		`
-	_, err := r.db.Exec(ctx, query, project.Name, project.Description, project.Status, project.Stack, project.RepositoryURL, project.DeploymentURL, project.UUID)
+	err := r.db.QueryRow(ctx, query, project.Name, project.Description, project.Status, project.Stack, project.RepositoryURL, project.DeploymentURL, project.UUID).Scan(&project.UpdatedAt)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -66,9 +66,11 @@ func (r *userRepository) Create(ctx context.Context, user *models.User) error {
 	query := `
 		INSERT INTO users (name, email, password_hash)
 		VALUES ($1, $2, $3)
-		RETURNING id, uuid
+		RETURNING id, uuid, created_at, updated_at
 	`
-	err := r.db.QueryRow(ctx, query, user.Name, user.Email, user.PasswordHash).Scan(&user.ID, &user.UUID)
+	err := r.db.QueryRow(ctx, query, user.Name, user.Email, user.PasswordHash).Scan(
+		&user.ID, &user.UUID, &user.CreatedAt, &user.UpdatedAt,
+	)
 	if err != nil {
 		return err
 	}
@@ -78,10 +80,11 @@ func (r *userRepository) Create(ctx context.Context, user *models.User) error {
 func (r *userRepository) Update(ctx context.Context, user *models.User) error {
 	query := `
 		UPDATE users
-		SET name = $1, email = $2
+		SET name = $1, email = $2, updated_at = NOW()
 		WHERE uuid = $3
+		RETURNING updated_at
 	`
-	_, err := r.db.Exec(ctx, query, user.Name, user.Email, user.UUID)
+	err := r.db.QueryRow(ctx, query, user.Name, user.Email, user.UUID).Scan(&user.UpdatedAt)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/utils/time.go
+++ b/backend/pkg/utils/time.go
@@ -1,0 +1,7 @@
+package utils
+
+import "time"
+
+func NowUTC() time.Time {
+	return time.Now().UTC()
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       POSTGRES_DB: dev_dashdb
       POSTGRES_USER: web
       POSTGRES_PASSWORD: webpass
+      TZ: UTC
+      PGTZ: UTC
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures all backend datetime values are stored and returned in UTC, and fixes missing or stale timestamp handling on create/update operations.

## Problems fixed

- **No UTC enforcement** — Postgres session timezone was unset, so `NOW()` depended on server/host TZ
- **Missing `updated_at` on user updates** — User `PUT` did not bump `updated_at` (projects already did)
- **Zero timestamps on create** — `INSERT` only returned `id`/`uuid`, so API create responses had `"0001-01-01T00:00:00Z"` for timestamps
- **Stale `updated_at` on update responses** — DB was updated but the in-memory struct was returned without the new timestamp

## changes

- Set `TZ=UTC` and `PGTZ=UTC` on the Postgres Docker service
- Set `SET TIME ZONE 'UTC'` on every pgx connection via `AfterConnect`
- Add `pkg/utils/NowUTC()` helper and use it in test mocks
- Extend `CREATE` queries to `RETURNING created_at, updated_at`
- Extend `UPDATE` queries to set `updated_at = NOW()` and `RETURNING updated_at` (users and projects)
- Add migration `000005` with `BEFORE UPDATE` triggers to auto-bump `updated_at` as defense in depth

## Test plan

- [x] `go build ./...` passes
- [x] Unit tests pass: `go test -tags integration -v -count=1 ./Test/Unit/...`
- [ ] Integration tests (requires Docker): `make test-integration`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb319cae-f363-4eeb-b1b9-6990b3ce7c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb319cae-f363-4eeb-b1b9-6990b3ce7c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

